### PR TITLE
Fix right layout resizing with lyrics and button width in the Credits section of the right panel

### DIFF
--- a/_lyrics.sass
+++ b/_lyrics.sass
@@ -1,6 +1,7 @@
 // Don't change layout when lyrics are on
-.LayoutResizer__resize-bar.LayoutResizer__inline-start
-	display: none
+.Root__top-container:has(.lyrics-lyrics-container)
+	.LayoutResizer__resize-bar.LayoutResizer__inline-start
+		display: none
 
 // Change lyrics colors
 div[style*="--lyrics-color"]

--- a/_rootlist.sass
+++ b/_rootlist.sass
@@ -6,10 +6,6 @@
 .main-yourLibraryX-libraryRootlist
 	padding: 0
 
-// Bigger expansion size
-div.HeaderArea > div[class*=TrailingSlot]
-	width: 24px
-
 // Better expansion indicator
 div.HeaderArea > div > button.Button-buttonTertiary-small-iconOnly-useBrowserDefaultFocusStyle-condensedAll,
 div.HeaderArea > div > button.Button-buttonTertiary-small-iconOnly-isUsingKeyboard-useBrowserDefaultFocusStyle-condensedAll


### PR DESCRIPTION
This PR addresses two things:

1) Right layout resizer was simply disabled, I fixed it according to the comment (perhaps better to let the user resize anyway?)
    Before:
    <video src="https://github.com/user-attachments/assets/8eae526b-c0ca-4861-93ec-0241b3a1802f" />

    After:
    <video src="https://github.com/user-attachments/assets/f7fa12f1-eb7b-439f-8f4a-6658ed5f10c9" />

2) The buttons in the credit section were forced to 24px, making them look weird
    Before:
    ![Before](https://github.com/user-attachments/assets/ff3767f8-b24b-4347-aa7e-807a16b408f0)
    After:
    ![After](https://github.com/user-attachments/assets/8606c7e6-0b2e-4e85-bd14-56a82bd39ea2)